### PR TITLE
Fix build on x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be tag translation localestub
+LIBS = be tag translation localestub $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative

--- a/Makefile_armyknife_tte
+++ b/Makefile_armyknife_tte
@@ -78,7 +78,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be tag translation localestub
+LIBS = be tag translation localestub $(STDCPPLIBS)
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative

--- a/source/albumpictureview.cpp
+++ b/source/albumpictureview.cpp
@@ -160,7 +160,7 @@ AlbumPictureView::SetPicture(const char *path)
 	pictureFrame->setMimeType(mimeName);
 	pictureFrame->setType(TagLib::ID3v2::AttachedPictureFrame::FrontCover);
 	pictureFrame->setPicture(
-		TagLib::ByteVector(static_cast<char*>(buffer->Buffer()), buffer->BufferLength() + 1));
+		TagLib::ByteVector(static_cast<const char*>(buffer->Buffer()), buffer->BufferLength() + 1));
 	printf("drag:%i\n", fileTags->frameList("APIC").size());
 	fileTags->addFrame(pictureFrame);
 	printf("drag:%i\n", fileTags->frameList("APIC").size());

--- a/source/application.cpp
+++ b/source/application.cpp
@@ -55,7 +55,7 @@ Application::RefsReceived(BMessage* message)
 	m_window->PostMessage(message);
 }
 
-void
+int
 main()
 {
 	PRINT(("main()\n"));
@@ -63,6 +63,7 @@ main()
 	new Application();
 	be_app->Run();
 	delete be_app;
+	return 0;
 }
 
 void

--- a/source/appwindow.h
+++ b/source/appwindow.h
@@ -14,7 +14,7 @@ class AppWindow : public BWindow
 		AppWindow();
 		AppWindow(BMessage* archive);
 		~AppWindow();
-		static AppWindow* AppWindow::CreateWindow();
+		static AppWindow* CreateWindow();
 		virtual void MessageReceived(BMessage* message);
 		virtual bool QuitRequested();
 		virtual void FrameMoved(BPoint point);

--- a/source/editorview.cpp
+++ b/source/editorview.cpp
@@ -8,7 +8,6 @@
 #include <Entry.h>
 #include <File.h>
 #include <GroupLayout.h>
-#include <List.h>
 #include <Layout.h>
 #include <LayoutBuilder.h>
 #include <Message.h>
@@ -17,6 +16,7 @@
 #include <MenuItem.h>
 #include <Messenger.h>
 #include <NodeInfo.h>
+#include <ObjectList.h>
 #include <OptionPopUp.h>
 #include <Path.h>
 #include <RadioButton.h>
@@ -138,19 +138,18 @@ EditorView::InitView()
 	BMenu* menu = new BMenu(GENRE_LABEL);
 	menu->SetLabelFromMarked(true);
 	int genres = GenreList::NumGenres();
-	BList genreList;
+	BObjectList<const char> genreList;
 	for(int i=0;i<genres;i++)
 	{
-		char* genre = GenreList::Genre(i);
+		const char* genre = GenreList::Genre(i);
 		genreList.AddItem(genre);
-
 	}
 	genreList.SortItems(GenreList::GenreSort);
 	char last = 'A';
 	char current;
 	for(int i=0;i<genres;i++)
 	{
-		char* genre = (char*)genreList.ItemAt(i);
+		const char* genre = genreList.ItemAt(i);
 		current = genre[0];
 		if(current != last)
 		{

--- a/source/entryrefitem.cpp
+++ b/source/entryrefitem.cpp
@@ -392,7 +392,7 @@ EntryRefItem::IsAccepted()
 }
 
 void
-EntryRefItem::DrawItem(BView *owner, BRect frame, bool complete = false)
+EntryRefItem::DrawItem(BView *owner, BRect frame, bool complete)
 {
 	if (! m_file_accepted)
 	{

--- a/source/genrelist.cpp
+++ b/source/genrelist.cpp
@@ -5,7 +5,7 @@
 #define NUM_GENRES 115
 #define OTHER_INDEX 12
 
-char* genre_list[] =
+const char* genre_list[] =
 {
 	"Blues",
 	"Classic Rock",
@@ -134,7 +134,7 @@ GenreList::~GenreList()
 	PRINT(("GenreList::~GenreList()\n"));
 }
 
-char*
+const char*
 GenreList::Genre(int value)
 {
 	PRINT(("GenreList::Genre(int)\n"));
@@ -175,12 +175,9 @@ GenreList::NumGenres()
 }
 
 int
-GenreList::GenreSort(const void* g1, const void* g2)
+GenreList::GenreSort(const char* g1, const char* g2)
 {
 	//PRINT(("GenreList::GenreSort()\n"));
-
-	char* genre1 = *((char**) g1);
-	char* genre2 = *((char**) g2);
-	return strcmp(genre1,genre2);
+	return strcmp(g1,g2);
 }
 

--- a/source/genrelist.h
+++ b/source/genrelist.h
@@ -7,10 +7,10 @@ class GenreList
 		GenreList();
 		~GenreList();
 
-		static char* Genre(int value);
+		static const char* Genre(int value);
 		static int Genre(const char* value);
 		static int NumGenres();
-		static int GenreSort(const void* g1, const void* g2);
+		static int GenreSort(const char* g1, const char* g2);
 };
 
 #endif

--- a/source/picklistview.cpp
+++ b/source/picklistview.cpp
@@ -14,9 +14,7 @@
 #include "picklistview.h"
 //#include "appview.h"
 
-PickListView::PickListView(const char* name = NULL,
-	uint32 flags = B_WILL_DRAW |  B_NAVIGABLE_JUMP,
-	border_style border = B_FANCY_BORDER) :
+PickListView::PickListView(const char* name, uint32 flags, border_style border) :
 		BBox(name, flags, border)
 {
 	PRINT(("PickListView::PickListView(BRect,const char*,uint32,uint32,border_style)\n"));
@@ -66,7 +64,7 @@ PickListView::Instantiate(BMessage* archive)
 }
 
 status_t
-PickListView::Archive(BMessage* archive, bool deep=true) const
+PickListView::Archive(BMessage* archive, bool deep) const
 {
 	PRINT(("PickListView::Archive(BMessage*,bool)\n"));
 


### PR DESCRIPTION
There is one more issue which only produces a warning regarding using string literals as char* in the genre list, however fixing this seems rather involved, having to change signatures across several files. There is also a BList involved, which does interesting things with `const void*/void*` which do not seem to go well with this change, so you essentially have to add another layer of pointer indirection, but I couldn't convince the type checker to let me do this last night.