### PR TITLE
Add online tag lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 objects*/
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,15 @@ SRCS = \
 	source/genrelist.cpp \
 	source/id3tag.cpp \
 	source/id3tags.cpp \
+	source/musicbrainzquery.cpp \
 	source/mpegview.cpp \
 	source/naview.cpp \
 	source/nawindow.cpp \
 	source/picklistview.cpp \
 	source/preferences.cpp \
+	source/query.cpp \
+	source/queryable.cpp \
+	source/querywindow.cpp \
 	source/taview.cpp \
 	source/ttinfoview.cpp
 
@@ -78,7 +82,7 @@ RSRCS =
 #	- 	if your library does not follow the standard library naming scheme,
 #		you need to specify the path to the library and it's name.
 #		(e.g. for mylib.a, specify "mylib.a" or "path/mylib.a")
-LIBS = be tag translation localestub $(STDCPPLIBS)
+LIBS = be tag translation localestub $(STDCPPLIBS) musicbrainz5 columnlistview
 
 #	Specify additional paths to directories following the standard libXXX.so
 #	or libXXX.a naming scheme. You can specify full paths or paths relative
@@ -90,7 +94,7 @@ LIBPATHS =
 #	Additional paths to look for system headers. These use the form
 #	"#include <header>". Directories that contain the files in SRCS are
 #	NOT auto-included here.
-SYSTEM_INCLUDE_PATHS = 
+SYSTEM_INCLUDE_PATHS = /system/develop/headers/private/interface
 
 #	Additional paths paths to look for local headers. These use the form
 #	#include "header". Directories that contain the files in SRCS are

--- a/locales/de.catkeys
+++ b/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	German	application/x-vnd.armyknife	2439916034
+1	German	application/x-vnd.armyknife	3412892590
 MPEG	Mode menu		MPEG
 Genre	Tag type		Genre
 0 have ID3v1 tags.	MPEG information		0 haben ID3v1-Tags.
@@ -12,6 +12,7 @@ Tags	Edit mode operation		Tags
 Select All Unsupported	Edit menu: Selecting files		Alle nicht Unterstützten auswählen
 Next Mode	Mode menu		Nächster Modus
 Paste	Edit menu: Copy/Paste		Einfügen
+Online Tag Lookup	Window title		Online-Tag-Suche
 Name → Attributes	Conversion type		Name → Attribute
 Year	Tag type		Jahr
 Info	MPEG information		Info
@@ -32,16 +33,19 @@ About...	File menu		Über...
 idle	Status		untätig
 Add/Remove	MPEG operation		Hinzufügen/Entfernen
 Track	Tag type		Nummer
+Working…	Query lookup button		Arbeitet…
 Cancel	Main action		Abbrechen
 Apply	Main action		Anwenden
 Tags → Attributes	Conversion type		Tags → Attribute
 Name	Mode menu		Name
 Also Apply To Attributes	Edit mode operation		Auch auf Attribute anwenden
+Show More	Query lookup button		Mehr anzeigen
 First File	Edit menu: Selecting files		Erste Datei
 Attributes	Edit mode operation		Attribute
 Genre = /g	Pattern explanation	Leave /g untouched.	Genre = /g
 0 have ID3v2 tags.	MPEG information		0 haben ID3v2-Tags.
 Year = /y	Pattern explanation	Leave /y untouched.	Jahr = /y
+No more results	Query lookup button		Keine weiteren Ergebnisse
 Previous File	Edit menu: Selecting files		Vorherige Datei
 Cut	Edit menu: Copy/Paste		Ausschneiden
 Also Apply To Tags	Edit mode operation		Auch auf Tags anwenden
@@ -53,6 +57,7 @@ Attributes → Tags	Conversion type		Attribute → Tags
 Comment	Tag type		Kommentar
 Wildcard = /*	Pattern explanation	Leave /* untouched.	Beliebig = /*
 Artist	Tag type		Künstler
+Online Tag Lookup…	Editor view button		Online-Tag-Suche…
 Edit	Edit menu: Copy/Paste		Bearbeiten
 The Army Knife	System name		The Army Knife
 Artist = /a	Pattern explanation	Leave /a untouched.	Künstler = /a

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.armyknife	2439916034
+1	English	application/x-vnd.armyknife	3412892590
 MPEG	Mode menu		MPEG
 Genre	Tag type		Genre
 0 have ID3v1 tags.	MPEG information		0 have ID3v1 tags.
@@ -12,6 +12,7 @@ Tags	Edit mode operation		Tags
 Select All Unsupported	Edit menu: Selecting files		Select All Unsupported
 Next Mode	Mode menu		Next Mode
 Paste	Edit menu: Copy/Paste		Paste
+Online Tag Lookup	Window title		Online Tag Lookup
 Name → Attributes	Conversion type		Name → Attributes
 Year	Tag type		Year
 Info	MPEG information		Info
@@ -32,16 +33,19 @@ About...	File menu		About...
 idle	Status		idle
 Add/Remove	MPEG operation		Add/Remove
 Track	Tag type		Track
+Working…	Query lookup button		Working…
 Cancel	Main action		Cancel
 Apply	Main action		Apply
 Tags → Attributes	Conversion type		Tags → Attributes
 Name	Mode menu		Name
 Also Apply To Attributes	Edit mode operation		Also Apply To Attributes
+Show More	Query lookup button		Show More
 First File	Edit menu: Selecting files		First File
 Attributes	Edit mode operation		Attributes
 Genre = /g	Pattern explanation	Leave /g untouched.	Genre = /g
 0 have ID3v2 tags.	MPEG information		0 have ID3v2 tags.
 Year = /y	Pattern explanation	Leave /y untouched.	Year = /y
+No more results	Query lookup button		No more results
 Previous File	Edit menu: Selecting files		Previous File
 Cut	Edit menu: Copy/Paste		Cut
 Also Apply To Tags	Edit mode operation		Also Apply To Tags
@@ -54,6 +58,7 @@ Comment	Tag type		Comment
 Wildcard = /*	Pattern explanation	Leave /* untouched.	Wildcard = /*
 Artist	Tag type		Artist
 Edit	Edit menu: Copy/Paste		Edit
+Online Tag Lookup…	Editor view button		Online Tag Lookup…
 The Army Knife	System name		The Army Knife
 Artist = /a	Pattern explanation	Leave /a untouched.	Artist = /a
 Title = /t	Pattern explanation	Leave /t untouched.	Title = /t

--- a/source/albumpictureview.cpp
+++ b/source/albumpictureview.cpp
@@ -11,7 +11,8 @@
 #include "guistrings.h"
 
 AlbumPictureView::AlbumPictureView(const char *name)
-	: BView(name, B_WILL_DRAW)
+	:	BView(name, B_WILL_DRAW),
+		m_bitmap(NULL)
 {
 	SetExplicitPreferredSize(BSize(160, 160));
 	SetExplicitMinSize(BSize(160, 160));

--- a/source/appdefs.h
+++ b/source/appdefs.h
@@ -17,7 +17,7 @@
 #define SIGNATURE "application/x-vnd.armyknife"
 #endif
 
-#define VERSION "5.0.0"
+#define VERSION "5.1.0"
 
 #define PROJECT_DIR "FlipSide Software"
 #define WINDOW_FILE "window"

--- a/source/armyknife.rdef
+++ b/source/armyknife.rdef
@@ -77,7 +77,7 @@ resource file_types message {
 
 resource app_version {
 	major  = 5,
-	middle = 0,
+	middle = 1,
 	minor  = 0,
 
 	variety = B_APPV_FINAL,

--- a/source/commandconstants.h
+++ b/source/commandconstants.h
@@ -67,4 +67,9 @@
 #define MSG_EDIT_COPY '092'
 #define MSG_EDIT_PASTE '093'
 
+#define MSG_TAG_LOOKUP '094'
+#define MSG_ADOPT_TAGS '095'
+#define MSG_SHOW_MORE '096'
+#define MSG_UPDATE_BUTTON '097'
+
 #endif

--- a/source/editorview.h
+++ b/source/editorview.h
@@ -75,6 +75,7 @@ class EditorView : public AddOnView
 #endif
 		BBox*			m_edit_box;
 		BBox*			m_genre_box;
+		BButton*		m_tag_lookup;
 
 		bool			m_album_picture_changed;
 

--- a/source/guistrings.h
+++ b/source/guistrings.h
@@ -7,6 +7,7 @@
 
 #define WIN_TITLE B_TRANSLATE_SYSTEM_NAME(APPLICATION)
 #define PREF_TITLE B_TRANSLATE_CONTEXT("The Army Knife Preferences", "Window title")
+#define LOOKUP_TITLE B_TRANSLATE_CONTEXT("Online Tag Lookup", "Window title")
 
 #define FILE_MENU B_TRANSLATE_CONTEXT("File", "File menu")
 #define ABOUT_ITEM B_TRANSLATE_CONTEXT("About...", "File menu")
@@ -128,5 +129,10 @@
 #define COMPOSER_LABEL "Composer"
 #define GENDER_LABEL "Gender"
 #endif
+
+#define QUERY_START_QUERY B_TRANSLATE_CONTEXT("Online Tag Lookup" B_UTF8_ELLIPSIS, "Editor view button")
+#define QUERY_MORE B_TRANSLATE_CONTEXT("Show More", "Query lookup button")
+#define QUERY_WORKING B_TRANSLATE_CONTEXT("Working" B_UTF8_ELLIPSIS, "Query lookup button")
+#define QUERY_NO_MORE_RESULTS B_TRANSLATE_CONTEXT("No more results", "Query lookup button")
 
 #endif

--- a/source/musicbrainzquery.cpp
+++ b/source/musicbrainzquery.cpp
@@ -1,0 +1,134 @@
+#include "musicbrainzquery.h"
+
+#include <exception>
+
+#include <Debug.h>
+
+#include <musicbrainz5/Artist.h>
+#include <musicbrainz5/ArtistCredit.h>
+#include <musicbrainz5/Medium.h>
+#include <musicbrainz5/NameCredit.h>
+#include <musicbrainz5/NameCreditList.h>
+#include <musicbrainz5/Query.h>
+#include <musicbrainz5/Recording.h>
+#include <musicbrainz5/Release.h>
+#include <musicbrainz5/Track.h>
+
+#include "appdefs.h"
+
+MusicBrainzQuery::MusicBrainzQuery(Queryable original)
+	:
+	Query(),
+	m_total_count(-1),
+	m_next_count(0)
+{
+	PRINT(("MusicBrainzQuery::MusicBrainzQuery(Queryable)\n"));
+
+	if (original.Artist() != NULL)
+		m_query_string << "artist:\"" << original.Artist() << "\" AND ";
+
+	if (original.Album() != NULL)
+		m_query_string << "release:\"" << original.Album() << "\" AND ";
+
+	if (original.Title() != NULL)
+		m_query_string << "recording:\"" << original.Title() << "\" AND ";
+
+	if (original.Year() != NULL)
+		m_query_string << "date:\"" << original.Year() << "\" AND ";
+
+	if (original.Comment() != NULL)
+		m_query_string << "comment:\"" << original.Comment() << "\" AND ";
+
+	if (original.Track() != NULL)
+		m_query_string << "tnum:\"" << original.Track() << "\" AND ";
+
+	// Get rid of the final " AND "
+	if (m_query_string.Length() > 5);
+		m_query_string.Truncate(m_query_string.Length() - 5);
+}
+
+MusicBrainzQuery::~MusicBrainzQuery()
+{
+	PRINT(("MusicBrainzQuery::~MusicBrainzQuery()\n"));
+}
+
+BString
+MakeArtist(MusicBrainz5::CArtistCredit* credit)
+{
+	MusicBrainz5::CNameCreditList* list = credit->NameCreditList();
+
+	BString res;
+	for (int32 i = 0; i < list->NumItems(); i++) {
+		MusicBrainz5::CNameCredit* single = list->Item(i);
+		res << single->Artist()->Name().c_str() << single->JoinPhrase().c_str();
+	}
+	return res;
+}
+
+status_t
+MusicBrainzQuery::RefillBuffer()
+{
+	PRINT(("MusicBrainzQuery::RefillBuffer()\n"));
+
+	m_buffer.erase(m_buffer.begin(), m_buffer.end());
+
+	if (m_total_count == m_next_count)
+		return B_ERROR;
+
+	MusicBrainz5::CQuery query("ArmyKnife " VERSION " for Haiku (https://github.com/HaikuArchives/ArmyKnife)");
+
+	try {
+		MusicBrainz5::CQuery::tParamMap params;
+
+		params["query"] = m_query_string.String();
+		BString c1;
+		c1 << k_fetch_size;
+		params["limit"] = c1.String();
+
+		BString c2;
+		c2 << m_next_count;
+		params["offset"] = c2.String();
+
+		MusicBrainz5::CMetadata result = query.Query("recording", "", "", params);
+		MusicBrainz5::CRecordingList* results = result.RecordingList();
+
+		if (results == NULL)
+			return B_ERROR;
+
+		m_total_count = results->Count();
+		m_next_count += results->NumItems();
+		for (int32 i = 0; i < results->NumItems(); i++) {
+			MusicBrainz5::CRecording* recording = results->Item(i);
+			Queryable templ;
+
+			templ.SetTitle(recording->Title().c_str());
+			templ.SetComment(recording->Disambiguation().c_str());
+			templ.SetArtist(MakeArtist(recording->ArtistCredit()).String());
+
+			MusicBrainz5::CReleaseList* releases = recording->ReleaseList();
+
+			if (releases == NULL)
+				continue;
+
+			for (int32 j = 0; j < releases->NumItems(); j++) {
+				MusicBrainz5::CRelease* release = releases->Item(j);
+				Queryable toAdd = templ; // Copy
+
+				toAdd.SetAlbum(release->Title().c_str());
+				toAdd.SetYear(release->Date().c_str());
+				toAdd.SetTrack(release
+					->MediumList()->Item(0)
+					->TrackList()->Item(0)
+					->Number().c_str());
+
+				m_buffer.push_back(toAdd);
+			}
+		}
+		return m_buffer.size() > 0 ? B_OK : B_ERROR;
+	}
+	catch (std::exception& ex) {
+		std::cout << "An exception occurred: " << ex.what() << std::endl;
+		// Check whether there was an actual error or simply throttling
+		return query.LastHTTPCode() == 503 ? B_BUSY : B_ERROR;
+	}
+}

--- a/source/musicbrainzquery.h
+++ b/source/musicbrainzquery.h
@@ -1,0 +1,27 @@
+#ifndef _MUSIC_BRAINZ_QUERY_H__
+#define _MUSIC_BRAINZ_QUERY_H__
+
+#include <String.h>
+
+#include "query.h"
+
+
+class MusicBrainzQuery : public Query
+{
+	public:
+		MusicBrainzQuery(Queryable original);
+		virtual ~MusicBrainzQuery();
+
+	protected:
+		virtual status_t RefillBuffer();
+
+	private:
+		static const int k_fetch_size = 10;
+
+		BString m_query_string;;
+		int32 m_total_count;
+		int32 m_next_count;
+};
+
+#endif
+

--- a/source/query.cpp
+++ b/source/query.cpp
@@ -1,0 +1,40 @@
+#include "query.h"
+
+#include <Debug.h>
+
+Query::Query()
+	:
+	m_buffer_size(-1),
+	m_buffer_position(0)
+{
+	PRINT(("Query::Query()\n"));
+}
+
+Query::~Query()
+{
+	PRINT(("Query::~Query()\n"));
+}
+
+status_t
+Query::HasNextResult()
+{
+	PRINT(("Query::HasNextResult()\n"));
+
+	if (m_buffer_size == 0)
+		return B_ERROR;
+
+	if (m_buffer_position < m_buffer_size)
+		return B_OK;
+
+	m_buffer_position = 0;
+	status_t result = RefillBuffer();
+	m_buffer_size = m_buffer.size();
+	return result;
+}
+
+Queryable
+Query::GetNextResult()
+{
+	PRINT(("Query::GetNextResult()\n"));
+	return m_buffer[m_buffer_position++];
+}

--- a/source/query.h
+++ b/source/query.h
@@ -1,0 +1,30 @@
+#ifndef _QUERY_H__
+#define _QUERY_H__
+
+#include <vector>
+
+#include <SupportDefs.h>
+
+#include "queryable.h"
+
+class Query
+{
+	public:
+		Query();
+		virtual ~Query();
+
+		virtual status_t HasNextResult();
+		virtual Queryable GetNextResult();
+
+	protected:
+		virtual status_t RefillBuffer() = 0;
+
+		std::vector<Queryable> m_buffer;
+		int32 m_buffer_size;
+
+	private:
+		int32 m_buffer_position;
+};
+
+#endif
+

--- a/source/queryable.cpp
+++ b/source/queryable.cpp
@@ -1,0 +1,225 @@
+#include "queryable.h"
+
+#include <iostream>
+#include <string.h>
+
+#include <Debug.h>
+#include <SupportDefs.h>
+
+Queryable::Queryable()
+	:
+	BArchivable(),
+	m_artist(NULL),
+	m_album(NULL),
+	m_title(NULL),
+	m_year(NULL),
+	m_comment(NULL),
+	m_track(NULL)
+{
+	PRINT(("Queryable::Queryable()\n"));
+}
+
+Queryable::Queryable(const Queryable& other)
+	:
+	BArchivable(),
+	m_artist(strdup(other.Artist())),
+	m_album(strdup(other.Album())),
+	m_title(strdup(other.Title())),
+	m_year(strdup(other.Year())),
+	m_comment(strdup(other.Comment())),
+	m_track(strdup(other.Track()))
+{
+	PRINT(("Queryable::Queryable(const Queryable&)\n"));
+}
+
+Queryable::Queryable(BMessage* from)
+	:
+	BArchivable(from),
+	m_artist(NULL),
+	m_album(NULL),
+	m_title(NULL),
+	m_year(NULL),
+	m_comment(NULL),
+	m_track(NULL)
+{
+	PRINT(("Queryable::Quertable(BMessage*)\n"));
+
+	if (from == NULL)
+		return;
+
+	const char* artist;
+	const char* album;
+	const char* title;
+	const char* year;
+	const char* comment;
+	const char* track;
+
+	// If FindString does not find the field, it sets the pointer to NULL
+	from->FindString("m_artist", &artist);
+	from->FindString("m_album", &album);
+	from->FindString("m_title", &title);
+	from->FindString("m_year", &year);
+	from->FindString("m_comment", &comment);
+	from->FindString("m_track", &track);
+
+	m_artist = strdup(artist);
+	m_album = strdup(album);
+	m_title = strdup(title);
+	m_year = strdup(year);
+	m_comment = strdup(comment);
+	m_track = strdup(track);
+}
+
+Queryable::~Queryable()
+{
+	PRINT(("Queryable::~Queryable()\n"));
+
+	delete m_artist;
+	delete m_album;
+	delete m_title;
+	delete m_year;
+	delete m_comment;
+	delete m_track;
+}
+
+status_t
+Queryable::Archive(BMessage* into, bool deep) const
+{
+	PRINT(("Queryable::Archive(BMessage*, bool)\n"));
+
+	status_t status = BArchivable::Archive(into, deep);
+
+	if (status == B_OK && m_artist != NULL)
+		status = into->AddString("m_artist", m_artist);
+
+	if (status == B_OK && m_album != NULL)
+		status = into->AddString("m_album", m_album);
+
+	if (status == B_OK && m_title != NULL)
+		status = into->AddString("m_title", m_title);
+
+	if (status == B_OK && m_year != NULL)
+		status = into->AddString("m_year", m_year);
+
+	if (status == B_OK && m_comment != NULL)
+		status = into->AddString("m_comment", m_comment);
+
+	if (status == B_OK && m_track != NULL)
+		status = into->AddString("m_track", m_track);
+
+	if (status == B_OK)
+		status = into->AddString("class", "Queryable");
+
+	return status;
+}
+
+BArchivable*
+Queryable::Instantiate(BMessage* archive)
+{
+	if (validate_instantiation(archive, "Queryable"))
+		return new Queryable(archive);
+
+	return NULL;
+}
+
+const char*
+Queryable::Artist() const
+{
+	PRINT(("Queryable::Artist()\n"));
+	return m_artist;
+}
+
+const char*
+Queryable::Album() const
+{
+	PRINT(("Queryable::Album()\n"));
+	return m_album;
+}
+
+const char*
+Queryable::Title() const
+{
+	PRINT(("Queryable::Title()\n"));
+	return m_title;
+}
+
+const char*
+Queryable::Year() const
+{
+	PRINT(("Queryable::Year()\n"));
+	return m_year;
+}
+
+const char*
+Queryable::Comment() const
+{
+	PRINT(("Queryable::Comment()\n"));
+	return m_comment;
+}
+
+const char*
+Queryable::Track() const
+{
+	PRINT(("Queryable::Track()\n"));
+	return m_track;
+}
+
+void
+Queryable::SetArtist(const char* value)
+{
+	PRINT(("Queryable::SetArtist(const char*)\n"));
+	delete m_artist;
+	m_artist = strdup(value);
+}
+
+void
+Queryable::SetAlbum(const char* value)
+{
+	PRINT(("Queryable::SetAlbum(const char*)\n"));
+	delete m_album;
+	m_album = strdup(value);
+}
+
+void
+Queryable::SetTitle(const char* value)
+{
+	PRINT(("Queryable::SetTitle(const char*)\n"));
+	delete m_title;
+	m_title = strdup(value);
+}
+
+void
+Queryable::SetYear(const char* value)
+{
+	PRINT(("Queryable::SetYear(const char*)\n"));
+	delete m_year;
+	m_year = strdup(value);
+}
+
+void
+Queryable::SetComment(const char* value)
+{
+	PRINT(("Queryable::SetComment(const char*)\n"));
+	delete m_comment;
+	m_comment = strdup(value);
+}
+
+void
+Queryable::SetTrack(const char* value)
+{
+	PRINT(("Queryable::SetTrack(const char*)\n"));
+	delete m_track;
+	m_track = strdup(value);
+}
+
+void
+Queryable::PrintToStream()
+{
+	std::cout << std::endl
+		<< "Artist  = " << Artist() << std::endl
+		<< "Album   = " << Album() << std::endl
+		<< "Title   = " << Title() << std::endl
+		<< "Year    = " << Year() << std::endl
+		<< "Comment = " << Comment() << std::endl
+		<< "Track   = " << Track() << std::endl;
+}

--- a/source/queryable.h
+++ b/source/queryable.h
@@ -1,0 +1,43 @@
+#ifndef _QUERYABLE_H__
+#define _QUERYABLE_H__
+
+#include <Archivable.h>
+
+class Queryable : public BArchivable
+{
+	public:
+		Queryable();
+		Queryable(const Queryable& other);
+		Queryable(BMessage* from);
+		~Queryable();
+
+		status_t Archive(BMessage* into, bool deep = true) const;
+		static BArchivable* Instantiate(BMessage* archive);
+
+		const char* Artist() const;
+		const char* Album() const;
+		const char* Title() const;
+		const char* Year() const;
+		const char* Comment() const;
+		const char* Track() const;
+
+		void SetArtist(const char* value);
+		void SetAlbum(const char* value);
+		void SetTitle(const char* value);
+		void SetYear(const char* value);
+		void SetComment(const char* value);
+		void SetTrack(const char* value);
+
+		void PrintToStream();
+
+	private:
+		char* m_artist;
+		char* m_album;
+		char* m_title;
+		char* m_year;
+		char* m_comment;
+		char* m_track;
+};
+
+#endif
+

--- a/source/querywindow.cpp
+++ b/source/querywindow.cpp
@@ -1,0 +1,193 @@
+#include "querywindow.h"
+
+#include <Button.h>
+#include <ColumnListView.h>
+#include <ColumnTypes.h>
+#include <Debug.h>
+#include <LayoutBuilder.h>
+#include <Message.h>
+
+#include "commandconstants.h"
+#include "guistrings.h"
+#include "query.h"
+
+QueryWindow::QueryWindow(Query* query, BMessenger replyTo)
+	:
+	BWindow(BRect(0, 0, 1000, 400), LOOKUP_TITLE, B_TITLED_WINDOW,
+		B_AUTO_UPDATE_SIZE_LIMITS),
+	m_reply_to(replyTo)
+{
+	PRINT(("QueryWindow::QueryWindow(Query*, BMessenger)\n"));
+
+	m_worker = new QueryWindow::Worker(query, BMessenger(this));
+	m_worker->Run();
+
+	m_result_view = new BColumnListView("m_result_view", 0);
+
+	m_result_view->AddColumn(new BStringColumn(ARTIST_LABEL, 200, 50, 1000,
+		B_TRUNCATE_END), 0);
+
+	m_result_view->AddColumn(new BStringColumn(TITLE_LABEL, 200, 50, 1000,
+		B_TRUNCATE_END), 1);
+
+	m_result_view->AddColumn(new BStringColumn(ALBUM_LABEL, 200, 50, 1000,
+		B_TRUNCATE_END), 2);
+
+	m_result_view->AddColumn(new BStringColumn(TRACK_LABEL, 60, 50, 1000,
+		B_TRUNCATE_END), 3);
+
+	m_result_view->AddColumn(new BStringColumn(YEAR_LABEL, 60, 50, 1000,
+		B_TRUNCATE_END), 4);
+
+	m_result_view->AddColumn(new BStringColumn(COMMENT_LABEL, 400, 50, 1000,
+		B_TRUNCATE_END), 5);
+
+	m_result_view->SetInvocationMessage(new BMessage(MSG_APPLY));
+	m_result_view->SetSelectionMessage(new BMessage(SELECTION_CHANGED));
+
+	m_more = new BButton("more", QUERY_MORE, new BMessage(MSG_SHOW_MORE));
+	m_more->SetTarget(m_worker);
+	BButton* cancel = new BButton("cancel", CANCEL_BUTTON, new BMessage(B_QUIT_REQUESTED));
+	m_apply = new BButton("apply", APPLY_BUTTON, new BMessage(MSG_APPLY));
+	m_apply->SetEnabled(false);
+
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.SetInsets(B_USE_WINDOW_INSETS)
+		.Add(m_result_view)
+		.AddGroup(B_HORIZONTAL)
+			.Add(m_more)
+			.AddGlue()
+			.Add(cancel)
+			.Add(m_apply);
+
+	BMessenger(m_worker).SendMessage(MSG_SHOW_MORE);
+
+	CenterOnScreen();
+}
+
+QueryWindow::~QueryWindow()
+{
+	PRINT(("QueryWindow::~QueryWindow()\n"));
+
+	BMessenger(m_worker).SendMessage(B_QUIT_REQUESTED);
+}
+
+void
+QueryWindow::MessageReceived(BMessage* message)
+{
+	PRINT(("QueryWindow::MessageReceived(BMessage*)\n"));
+
+	switch (message->what) {
+		case MSG_SHOW_MORE:
+		{
+			void* ptr;
+			if (message->FindPointer("row", &ptr) == B_OK)
+				m_result_view->AddRow(static_cast<BRow*>(ptr));
+			break;
+		}
+
+		case MSG_APPLY:
+		{
+			BMessage adopt(MSG_ADOPT_TAGS);
+			m_worker->m_records.ItemAt(m_result_view->IndexOf(
+					m_result_view->CurrentSelection()))->Archive(&adopt);
+			m_reply_to.SendMessage(&adopt);
+			BMessenger(this).SendMessage(B_QUIT_REQUESTED);
+			break;
+		}
+
+		case MSG_UPDATE_BUTTON:
+		{
+			const char* label;
+			if (message->FindString("label", &label) == B_OK)
+				m_more->SetLabel(label);
+
+			bool enabled;
+			if (message->FindBool("enabled", &enabled) == B_OK)
+				m_more->SetEnabled(enabled);
+
+			break;
+		}
+
+		case SELECTION_CHANGED:
+			m_apply->SetEnabled(m_result_view->CurrentSelection() != NULL);
+			break;
+
+		default:
+			BWindow::MessageReceived(message);
+			break;
+	}
+}
+
+QueryWindow::Worker::Worker(Query* query, BMessenger reply_to)
+	:
+	BLooper(),
+	m_query(query),
+	m_reply_to(reply_to),
+	m_records(20, true)
+{
+	PRINT(("QueryWindow::Worker::Worker(Query*, BMessenger)\n"));
+}
+
+QueryWindow::Worker::~Worker()
+{
+	PRINT(("QueryWindow::Worker::~Worker()"));
+
+	delete m_query;
+}
+
+void
+QueryWindow::Worker::MessageReceived(BMessage* message)
+{
+	PRINT(("QueryWindow::Worker::MessageReceived(BMessage*)\n"));
+
+	switch (message->what)
+	{
+		case MSG_SHOW_MORE:
+		{
+			BMessage update(MSG_UPDATE_BUTTON);
+			update.AddBool("enabled", false);
+			update.AddString("label", QUERY_WORKING);
+			m_reply_to.SendMessage(&update);
+
+			int32 received = 0;
+			status_t result;
+			while (received < k_update_size && (result = m_query->HasNextResult()) == B_OK) {
+				Queryable* result = new Queryable(m_query->GetNextResult());
+				m_records.AddItem(result);
+
+				BRow* row = new BRow();
+				row->SetField(new BStringField(result->Artist()), 0);
+				row->SetField(new BStringField(result->Title()), 1);
+				row->SetField(new BStringField(result->Album()), 2);
+				row->SetField(new BStringField(result->Track()), 3);
+				row->SetField(new BStringField(result->Year()), 4);
+				row->SetField(new BStringField(result->Comment()), 5);
+
+				BMessage row_msg(MSG_SHOW_MORE);
+				row_msg.AddPointer("row", row);
+				m_reply_to.SendMessage(&row_msg);
+
+				received++;
+			}
+
+			BMessage post(MSG_UPDATE_BUTTON);
+			if (result != B_ERROR) {
+				post.AddString("label", QUERY_MORE);
+				post.AddBool("enabled", true);
+			} else {
+				post.AddString("label", QUERY_NO_MORE_RESULTS);
+			}
+			m_reply_to.SendMessage(&post);
+			break;
+		}
+
+		case SELECTION_CHANGED:
+			m_reply_to.SendMessage(message);
+			break;
+
+		default:
+			BLooper::MessageReceived(message);
+			break;
+	}
+}

--- a/source/querywindow.h
+++ b/source/querywindow.h
@@ -1,0 +1,52 @@
+#ifndef __QUERY_WINDOW_H__
+#define __QUERY_WINDOW_H__
+
+#include <Messenger.h>
+#include <ObjectList.h>
+#include <Window.h>
+
+#include "queryable.h"
+
+class BButton;
+class BColumnListView;
+class Query;
+
+class QueryWindow : public BWindow
+{
+	public:
+		QueryWindow(Query* query, BMessenger replyTo);
+		~QueryWindow();
+
+		void MessageReceived(BMessage* message);
+
+	private:
+		void ShowMore();
+
+		static const int32 k_update_size = 20;
+
+		BMessenger m_reply_to;
+		BColumnListView* m_result_view;
+		BButton* m_more;
+		BButton* m_apply;
+
+		class Worker : public BLooper
+		{
+			friend class QueryWindow;
+
+			public:
+				Worker(Query* query, BMessenger reply_to);
+				~Worker();
+
+				void MessageReceived(BMessage* message);
+
+			private:
+				BMessenger m_reply_to;
+				Query* m_query;
+				BObjectList<Queryable> m_records;
+		};
+
+		Worker* m_worker;
+};
+
+#endif
+


### PR DESCRIPTION
This PR adds a button for online tag search to the edit view. When clicked, a new window opens which shows MusicBrainz search results when searching for all activated, non-empty tags. Double-clicking a result or selecting it and hitting 'Apply' replaces the tags with the search results. Searching happens asynchronously. The API allows for adding other tag search services without changing the query window.

This requires the (new) package musicbrainz{_devel}-5.1.0-2 from haikuports (that is, revision 2).

This was done for https://codein.withgoogle.com/dashboard/task-instances/4824242864521216/?sp-page=1.