### PR TITLE
Japanese locale for ArmyKnife

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES = en de
+LOCALES = en de ja
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/Makefile_armyknife_tte
+++ b/Makefile_armyknife_tte
@@ -106,7 +106,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES = en de
+LOCALES = en de ja
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/locales/ja.catkeys
+++ b/locales/ja.catkeys
@@ -1,7 +1,7 @@
 1	Japanese	application/x-vnd.armyknife	3412892590
 MPEG	Mode menu		MPEG
 Genre	Tag type		ジャンル
-0 have ID3v1 tags.	MPEG information		0 は ID3v1 タグがあります。
+0 have ID3v1 tags.	MPEG information		0 ID3v1 タグあり
 Reset	Edit menu: Selecting files		初期設定
 No image	Status		画像無し
 Next File	Edit menu: Selecting files		次のファイル
@@ -18,7 +18,7 @@ Year	Tag type		年
 Info	MPEG information		情報
 Title	Tag type		曲名
 Excellent	About message	In context, this means \"dismiss\"	お疲れ
-0 have APE tags.	MPEG information		0 は APE タグがあります。
+0 have APE tags.	MPEG information		0 APE タグあり
 Select All	Edit menu: Selecting files		すべてを選択
 Album = /n	Pattern explanation	Leave /n untouched.	アルバム = /n
 Previous Mode	Mode menu		前のモード
@@ -43,7 +43,7 @@ Show More	Query lookup button		更に表示
 First File	Edit menu: Selecting files		先頭のファイル
 Attributes	Edit mode operation		属性
 Genre = /g	Pattern explanation	Leave /g untouched.	ジャンル = /g
-0 have ID3v2 tags.	MPEG information		0 は ID3v2 タグがあります。
+0 have ID3v2 tags.	MPEG information		0 ID3v2 タグあり
 Year = /y	Pattern explanation	Leave /y untouched.	年 = /y
 No more results	Query lookup button		結果は以上です。
 Previous File	Edit menu: Selecting files		前のファイル

--- a/locales/ja.catkeys
+++ b/locales/ja.catkeys
@@ -1,0 +1,69 @@
+1	Japanese	application/x-vnd.armyknife	3412892590
+MPEG	Mode menu		MPEG
+Genre	Tag type		ジャンル
+0 have ID3v1 tags.	MPEG information		0 は ID3v1 タグがあります。
+Reset	Edit menu: Selecting files		初期設定
+No image	Status		画像無し
+Next File	Edit menu: Selecting files		次のファイル
+Last File	Edit menu: Selecting files		末尾のファイル
+Copy	Edit menu: Copy/Paste		コピー
+Pattern:	Pattern label		パターン:
+Tags	Edit mode operation		タグ
+Select All Unsupported	Edit menu: Selecting files		非対応のすべてを選択
+Next Mode	Mode menu		次のモード
+Paste	Edit menu: Copy/Paste		貼り付け
+Online Tag Lookup	Window title		ネットでタグを検索
+Name → Attributes	Conversion type		名前 → 属性
+Year	Tag type		年
+Info	MPEG information		情報
+Title	Tag type		曲名
+Excellent	About message	In context, this means \"dismiss\"	お疲れ
+0 have APE tags.	MPEG information		0 は APE タグがあります。
+Select All	Edit menu: Selecting files		すべてを選択
+Album = /n	Pattern explanation	Leave /n untouched.	アルバム = /n
+Previous Mode	Mode menu		前のモード
+Clear List	Edit menu: Selecting files		消去
+Album	Tag type		アルバム
+Quit	File menu		終了
+Remove	MPEG operation		削除
+ selected	Main action		 選択中
+Copy	Mode menu		コピー
+0 files in selection.	MPEG information		0 ファイルが選択中。
+About...	File menu		The Army Knife について…
+idle	Status		停止中
+Add/Remove	MPEG operation		追加/削除
+Track	Tag type		トラック
+Working…	Query lookup button		処理中…
+Cancel	Main action		中止
+Apply	Main action		適用
+Tags → Attributes	Conversion type		タグ → 属性
+Name	Mode menu		名前
+Also Apply To Attributes	Edit mode operation		属性にも適用
+Show More	Query lookup button		更に表示
+First File	Edit menu: Selecting files		先頭のファイル
+Attributes	Edit mode operation		属性
+Genre = /g	Pattern explanation	Leave /g untouched.	ジャンル = /g
+0 have ID3v2 tags.	MPEG information		0 は ID3v2 タグがあります。
+Year = /y	Pattern explanation	Leave /y untouched.	年 = /y
+No more results	Query lookup button		結果は以上です。
+Previous File	Edit menu: Selecting files		前のファイル
+Cut	Edit menu: Copy/Paste		切り取り
+Also Apply To Tags	Edit mode operation		タグにも適用
+Edit	Mode menu		編集
+Mode	Mode menu		モード
+Add	Main action		追加
+File	File menu		ファイル
+Attributes → Tags	Conversion type		属性 → タグ
+Comment	Tag type		コメント
+Wildcard = /*	Pattern explanation	Leave /* untouched.	ワイルドカード = /*
+Artist	Tag type		アーティスト
+Edit	Edit menu: Copy/Paste		編集
+Online Tag Lookup…	Editor view button		ネットでタグを検索…
+The Army Knife	System name		The Army Knife
+Artist = /a	Pattern explanation	Leave /a untouched.	アーティスト = /a
+Title = /t	Pattern explanation	Leave /t untouched.	曲名 = /t
+Attributes → Name	Conversion type		属性 → 名前
+Track = /k	Pattern explanation	Leave /k untouched.	トラック = /k
+Reset	Main action		初期設定
+Comment = /c	Pattern explanation	Leave /c untouched.	コメント = /c
+Add	MPEG operation		追加

--- a/locales/ja.catkeys
+++ b/locales/ja.catkeys
@@ -1,7 +1,7 @@
 1	Japanese	application/x-vnd.armyknife	3412892590
 MPEG	Mode menu		MPEG
 Genre	Tag type		ジャンル
-0 have ID3v1 tags.	MPEG information		0 ID3v1 タグあり
+0 have ID3v1 tags.	MPEG information		0 ID3v1 タグ付
 Reset	Edit menu: Selecting files		初期設定
 No image	Status		画像無し
 Next File	Edit menu: Selecting files		次のファイル
@@ -18,7 +18,7 @@ Year	Tag type		年
 Info	MPEG information		情報
 Title	Tag type		曲名
 Excellent	About message	In context, this means \"dismiss\"	お疲れ
-0 have APE tags.	MPEG information		0 APE タグあり
+0 have APE tags.	MPEG information		0 APE タグ付
 Select All	Edit menu: Selecting files		すべてを選択
 Album = /n	Pattern explanation	Leave /n untouched.	アルバム = /n
 Previous Mode	Mode menu		前のモード
@@ -43,7 +43,7 @@ Show More	Query lookup button		更に表示
 First File	Edit menu: Selecting files		先頭のファイル
 Attributes	Edit mode operation		属性
 Genre = /g	Pattern explanation	Leave /g untouched.	ジャンル = /g
-0 have ID3v2 tags.	MPEG information		0 ID3v2 タグあり
+0 have ID3v2 tags.	MPEG information		0 ID3v2 タグ付
 Year = /y	Pattern explanation	Leave /y untouched.	年 = /y
 No more results	Query lookup button		結果は以上です。
 Previous File	Edit menu: Selecting files		前のファイル


### PR DESCRIPTION
Nothing dramatic here; just a ja.catkeys and the requisite additions to LOCALES in the Makefiles.

I noticed in the process of doing this that mpegview.cpp is ignoring the MPEG information strings (for how many files in the selection have which types of tag) with English strings in the process of formatting for single vs. plural. Both single/plural strings should be added to catkeys and I may try to take care of this.