### PR TITLE
Create Help menu

### DIFF
--- a/source/appdefs.h
+++ b/source/appdefs.h
@@ -22,6 +22,8 @@
 #define PROJECT_DIR "FlipSide Software"
 #define WINDOW_FILE "window"
 #define PREFS_FILE "preferences"
+#define DOCUMENTATION_DIR "Documentation"
+#define CHANGELOG_FILE "armyknife_changelog.txt"
 
 #define MP3_MIME_TYPE "audio/mpeg"
 #define OGG_MIME_TYPE "audio/ogg"

--- a/source/appdefs.h
+++ b/source/appdefs.h
@@ -23,6 +23,7 @@
 #define WINDOW_FILE "window"
 #define PREFS_FILE "preferences"
 #define DOCUMENTATION_DIR "Documentation"
+#define README_FILE "armyknife/readme.html"
 #define CHANGELOG_FILE "armyknife_changelog.txt"
 
 #define MP3_MIME_TYPE "audio/mpeg"

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -399,6 +399,9 @@ AppWindow::DisableInterface()
 	m_clear_list_menu_item->SetEnabled(false);
 	m_select_all_menu_item->SetEnabled(false);
 	m_select_all_unsupported_menu_item->SetEnabled(false);
+	m_help_menu->SetEnabled(false);
+	m_readme_item->SetEnabled(false);
+	m_changelog_item->SetEnabled(false);
 //	m_beep_menu_item->SetEnabled(false);
 }
 
@@ -420,5 +423,8 @@ AppWindow::EnableInterface()
 	m_clear_list_menu_item->SetEnabled(true);
 	m_select_all_menu_item->SetEnabled(true);
 	m_select_all_unsupported_menu_item->SetEnabled(true);
+	m_help_menu->SetEnabled(true);
+	m_readme_item->SetEnabled(true);
+	m_changelog_item->SetEnabled(true);
 //	m_beep_menu_item->SetEnabled(true);
 }

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -275,8 +275,7 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_CHANGELOG:
 		{
 			BPath path;
-			find_directory(B_USER_SETTINGS_DIRECTORY,&path);
-			path.Append(PROJECT_DIR);
+			find_directory(B_USER_APPS_DIRECTORY,&path);
 			path.Append(APPLICATION_DIR);
 			path.Append(DOCUMENTATION_DIR);
 			path.Append(CHANGELOG_FILE);

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -266,8 +266,13 @@ AppWindow::MessageReceived(BMessage* message)
 		
 		case MSG_README:
 		{
+			BPath path;
+			find_directory(B_APPS_DIRECTORY, &path);
+			path.Append(APPLICATION_DIR);
+			path.Append(DOCUMENTATION_DIR);
+			path.Append(README_FILE);
 			BMessage message(B_REFS_RECEIVED);
- 			message.AddString("url", ReadmeLoc);
+ 			message.AddString("url", path.Path());
  			be_roster->Launch("text/html", &message);
 			break;
 		}
@@ -275,7 +280,7 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_CHANGELOG:
 		{
 			BPath path;
-			find_directory(B_APPS_DIRECTORY,&path);
+			find_directory(B_APPS_DIRECTORY, &path);
 			path.Append(APPLICATION_DIR);
 			path.Append(DOCUMENTATION_DIR);
 			path.Append(CHANGELOG_FILE);

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -274,8 +274,14 @@ AppWindow::MessageReceived(BMessage* message)
 
 		case MSG_CHANGELOG:
 		{
+			BPath path;
+			find_directory(B_USER_SETTINGS_DIRECTORY,&path);
+			path.Append(PROJECT_DIR);
+			path.Append(APPLICATION_DIR);
+			path.Append(DOCUMENTATION_DIR);
+			path.Append(CHANGELOG_FILE);
 			BMessage message(B_REFS_RECEIVED);
- 			message.AddString("url", ChangelogLoc);
+ 			message.AddString("url", path.Path());
  			be_roster->Launch("text/html", &message);
 			break;
 		}

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -275,7 +275,7 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_CHANGELOG:
 		{
 			BPath path;
-			find_directory(B_USER_APPS_DIRECTORY,&path);
+			find_directory(B_APPS_DIRECTORY,&path);
 			path.Append(APPLICATION_DIR);
 			path.Append(DOCUMENTATION_DIR);
 			path.Append(CHANGELOG_FILE);

--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -15,6 +15,7 @@
 #include <File.h>
 #include <FindDirectory.h>
 #include <Path.h>
+#include <Roster.h>
 
 #include "appdefs.h"
 #include "application.h"
@@ -121,6 +122,16 @@ AppWindow::InitWindow()
 	m_mode_menu->AddItem(new BMenuItem(TT_INFO_MODE_NAME, new BMessage(MSG_TT_INFO_MODE), '5'));
 #endif
 	m_menu_bar->AddItem(m_mode_menu);
+
+	
+	m_help_menu = new BMenu(HELP_MENU);
+	m_readme_item = new BMenuItem(README_ITEM, new BMessage(MSG_README));
+	m_changelog_item = new BMenuItem(CHANGELOG_ITEM, new BMessage(MSG_CHANGELOG));
+
+	m_help_menu->AddItem(m_readme_item);
+	m_help_menu->AddItem(m_changelog_item);
+
+	m_menu_bar->AddItem(m_help_menu);
 
 	// create options menu
 	/*
@@ -252,7 +263,23 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_SELECT_ALL_UNSUPPORTED:
 			m_app_view->SelectAllUnsupported();
 			break;
+		
+		case MSG_README:
+		{
+			BMessage message(B_REFS_RECEIVED);
+ 			message.AddString("url", ReadmeLoc);
+ 			be_roster->Launch("text/html", &message);
+			break;
+		}
 
+		case MSG_CHANGELOG:
+		{
+			BMessage message(B_REFS_RECEIVED);
+ 			message.AddString("url", ChangelogLoc);
+ 			be_roster->Launch("text/html", &message);
+			break;
+		}
+		
 		default:
 			BWindow::MessageReceived(message);
 	}

--- a/source/appwindow.h
+++ b/source/appwindow.h
@@ -3,6 +3,7 @@
 
 #include <Menu.h>
 #include <Window.h>
+#include <String.h>
 
 static const BString ReadmeLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife/readme.html";
 static const BString ChangelogLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife_changelog.txt"; 

--- a/source/appwindow.h
+++ b/source/appwindow.h
@@ -4,6 +4,9 @@
 #include <Menu.h>
 #include <Window.h>
 
+static const BString ReadmeLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife/readme.html";
+static const BString ChangelogLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife_changelog.txt"; 
+
 class AppView;
 class BMessage;
 class Preferences;
@@ -33,6 +36,7 @@ class AppWindow : public BWindow
 		BMenu*		m_edit_menu;
 		BMenu*		m_mode_menu;
 		BMenu*		m_options_menu;
+		BMenu*		m_help_menu;
 		BMenuItem*	m_about_menu_item;
 		BMenuItem*	m_quit_menu_item;
 		BMenuItem*	m_cut_menu_item;
@@ -47,6 +51,8 @@ class AppWindow : public BWindow
 		BMenuItem*	m_select_all_menu_item;
 		BMenuItem*	m_select_all_unsupported_menu_item;
 		BMenuItem*	m_beep_menu_item;
+		BMenuItem*	m_readme_item;
+		BMenuItem*	m_changelog_item;
 
 };
 

--- a/source/appwindow.h
+++ b/source/appwindow.h
@@ -5,9 +5,6 @@
 #include <Window.h>
 #include <String.h>
 
-static const BString ReadmeLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife/readme.html";
-static const BString ChangelogLoc = "file:///boot/system/apps/ArmyKnife/Documentation/armyknife_changelog.txt"; 
-
 class AppView;
 class BMessage;
 class Preferences;

--- a/source/commandconstants.h
+++ b/source/commandconstants.h
@@ -56,6 +56,9 @@
 #define MSG_TT_INFO_MODE '044'
 #endif
 
+#define MSG_README '045'
+#define MSG_CHANGELOG '046'
+
 #define MSG_BEEP_ON_UNSUPPORTED '050'
 
 #define MSG_CLEAR_CHECKBOX '060'

--- a/source/guistrings.h
+++ b/source/guistrings.h
@@ -51,6 +51,10 @@
 #define FLAC_MODE_NAME B_TRANSLATE_CONTEXT("FLAC", "Mode menu")
 #define TT_INFO_MODE_NAME B_TRANSLATE_CONTEXT("Info", "Mode menu")
 
+#define HELP_MENU B_TRANSLATE_CONTEXT("Help", "Help menu")
+#define README_ITEM B_TRANSLATE_CONTEXT("Readme", "Help menu")
+#define CHANGELOG_ITEM B_TRANSLATE_CONTEXT("Changelog", "Help menu")
+
 #define OPTIONS_MENU B_TRANSLATE_CONTEXT("Options", "Options menu")
 #define BEEP_ON_UNSUPPORTED B_TRANSLATE_CONTEXT("Beep On Unsupported Files", "Options menu")
 


### PR DESCRIPTION
Help menu contains readme & changelog files, which are put in `/boot/system/apps/ArmyKnife/Documentation`
Should fix #22 
  
  
![capture](https://user-images.githubusercontent.com/19305859/34580619-3835abbe-f1c0-11e7-8294-a82de102d81a.PNG)
