### PR TITLE
Fix Documentation path & change button label

### DIFF
--- a/source/appwindow.cpp
+++ b/source/appwindow.cpp
@@ -267,10 +267,15 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_README:
 		{
 			BPath path;
-			find_directory(B_APPS_DIRECTORY, &path);
-			path.Append(APPLICATION_DIR);
+			app_info info;
+			be_roster->GetActiveAppInfo(&info);
+			BEntry entry(&info.ref);
+			
+			entry.GetPath(&path);
+			path.GetParent(&path);
 			path.Append(DOCUMENTATION_DIR);
 			path.Append(README_FILE);
+			
 			BMessage message(B_REFS_RECEIVED);
  			message.AddString("url", path.Path());
  			be_roster->Launch("text/html", &message);
@@ -280,10 +285,15 @@ AppWindow::MessageReceived(BMessage* message)
 		case MSG_CHANGELOG:
 		{
 			BPath path;
-			find_directory(B_APPS_DIRECTORY, &path);
-			path.Append(APPLICATION_DIR);
+			app_info info;
+			be_roster->GetActiveAppInfo(&info);
+			BEntry entry(&info.ref);
+			
+			entry.GetPath(&path);
+			path.GetParent(&path);
 			path.Append(DOCUMENTATION_DIR);
 			path.Append(CHANGELOG_FILE);
+			
 			BMessage message(B_REFS_RECEIVED);
  			message.AddString("url", path.Path());
  			be_roster->Launch("text/html", &message);

--- a/source/guistrings.h
+++ b/source/guistrings.h
@@ -109,7 +109,7 @@
 #define IDLE B_TRANSLATE_CONTEXT("idle", "Status")
 
 #define ADD_BUTTON B_TRANSLATE_CONTEXT("Add", "Main action")
-#define APPLY_BUTTON B_TRANSLATE_CONTEXT("Apply", "Main action")
+#define APPLY_BUTTON B_TRANSLATE_CONTEXT("Save", "Main action")
 #define RESET_BUTTON B_TRANSLATE_CONTEXT("Reset", "Main action")
 #define CANCEL_BUTTON B_TRANSLATE_CONTEXT("Cancel", "Main action")
 #define SELECTED_TEXT B_TRANSLATE_CONTEXT(" selected", "Main action")


### PR DESCRIPTION
This PR:
* fixes #20: The "Apply" button is now "Save" to avoid confusion.
* fixes #22: replaced `B_APPS_DIRECTORY` with a combo of `GetActiveAppInfo`, `GetPath`, and `GetParent` (learned these from "Filer" 😀 ) so that the program could get to its docs relatively.

  