### PR TITLE
armyknife, fix references to the documentation

### DIFF
--- a/source/appdefs.h
+++ b/source/appdefs.h
@@ -22,7 +22,7 @@
 #define PROJECT_DIR "FlipSide Software"
 #define WINDOW_FILE "window"
 #define PREFS_FILE "preferences"
-#define DOCUMENTATION_DIR "documentation"
+#define DOCUMENTATION_DIR "Documentation"
 #define README_FILE "armyknife/readme.html"
 #define CHANGELOG_FILE "changelog.txt"
 


### PR DESCRIPTION
The files are cp'd into $appsDir/ArmyKnife/`Documentation` (not `documentation`), this fixes opening them in the help menu